### PR TITLE
chore: remove redundant prefixes and suffixes from plot filenames

### DIFF
--- a/benchmarks.py
+++ b/benchmarks.py
@@ -105,7 +105,7 @@ class BenchmarkSuiteRunner:
             self.plot_generator.plot()
 
             if self.generate_pdf:
-                summary_images = sorted(test_output_dir.glob("auto_*.png"))
+                summary_images = sorted(test_output_dir.glob("*.png"))
                 pdf_path = generate_benchmark_summary_pdf(
                     benchmark_name=test_name,
                     images=summary_images,

--- a/generate.py
+++ b/generate.py
@@ -54,7 +54,7 @@ class PlotGenerator:
             )
             df_long = pd.DataFrame(rows)
 
-            file_path = build_dir / pathlib.Path(f"auto_{sanitize_filename(metric)}_with_error_bars.{image_format}")
+            file_path = build_dir / pathlib.Path(f"{sanitize_filename(metric)}.{image_format}")
             fig = make_plot_from_df(
                 metric,
                 df_long,


### PR DESCRIPTION
As @pixelkubek has pointed out, they are useless. All graphs are auto generated, summary graphs are generated in different dir, so `with_error_bars` is unnecessary.

## Test

All plots seems to be generated:

<img width="1323" height="1167" alt="image" src="https://github.com/user-attachments/assets/c11fc720-8f19-42d5-83d9-14a93f1612a6" />
<img width="1203" height="1070" alt="image" src="https://github.com/user-attachments/assets/dfd03f8b-2edf-4e06-add4-6e3c75e1fee4" />

PDF per summary also:
<img width="1308" height="762" alt="image" src="https://github.com/user-attachments/assets/f42f9685-005e-4c63-9fd9-4896c4b04071" />


PDF per all configs:

![Uploading image.png…]()

