### PR TITLE
refactor: cleanup benchmarks.py

### DIFF
--- a/benchmarks.py
+++ b/benchmarks.py
@@ -81,9 +81,7 @@ class BenchmarkSuiteRunner:
 
                 run_output_dir: Path = test_output_dir / f"run_{i}"
                 run_output_dir.mkdir(exist_ok=True, parents=True)
-                [shardless_metrics, sharded_metrics] = self._run_iteration(
-                    benchmark, run_output_dir, config_path, self.plot_generator
-                )
+                [shardless_metrics, sharded_metrics] = self._run_iteration(benchmark, run_output_dir, config_path)
                 metrics_runs.append({"run_id": i, "sharded": sharded_metrics, "shardless": shardless_metrics})
 
             (combined_sharded, combined_shardless) = join_stats(metrics_runs)
@@ -133,7 +131,7 @@ class BenchmarkSuiteRunner:
             merge_pdfs(input_pdfs=per_benchmark_pdfs, output_pdf=self.output_dir / SUITE_SUMMARY_PDF_FILENAME)
 
     def _run_iteration(
-        self, benchmark: Benchmark, run_output_dir: Path, config_path: Path, plot_generator: PlotGenerator
+        self, benchmark: Benchmark, run_output_dir: Path, config_path: Path
     ) -> tuple[TreeDict[dict[str, Any]], TreeDict[dict[str, dict[int, Any]]]]:
         result: dict[dict[str, Any]] = {}
 

--- a/benchmarks.py
+++ b/benchmarks.py
@@ -2,6 +2,7 @@ import argparse
 import subprocess
 from datetime import datetime
 from pathlib import Path
+from typing import Any
 
 from yaml import safe_dump, safe_load
 
@@ -16,6 +17,7 @@ from run_io import run_io_test
 from run_rpc import run_rpc_test
 from scylla_perf import PerfSimpleQueryTestRunner
 from stats import join_stats
+from tree import TreeDict
 
 SUITE_SUMMARY_PDF_FILENAME = "suite_summary.pdf"
 BENCHMARK_SUMMARY_FILENAME = "metrics_summary.yaml"
@@ -79,45 +81,9 @@ class BenchmarkSuiteRunner:
 
                 run_output_dir: Path = test_output_dir / f"run_{i}"
                 run_output_dir.mkdir(exist_ok=True, parents=True)
-
-                result: dict = None
-
-                if benchmark["type"] == "io":
-                    result = run_io_test(
-                        self.io_config,
-                        config_path,
-                        run_output_dir,
-                        self.backends,
-                        self.params["skip_async_workers_cpuset"],
-                    )
-                elif benchmark["type"] == "rpc":
-                    result = run_rpc_test(
-                        self.rpc_config,
-                        config_path,
-                        run_output_dir,
-                        self.backends,
-                        self.params["skip_async_workers_cpuset"],
-                    )
-                elif benchmark["type"] == "simple-query":
-                    result = PerfSimpleQueryTestRunner(
-                        self.scylla_config,
-                        config_path,
-                        run_output_dir,
-                        self.backends,
-                        self.params["skip_async_workers_cpuset"],
-                    ).run()
-                else:
-                    raise Exception(f"Unknown benchmark type {benchmark['type']}")
-
-                backends_parsed = {}
-                for backend, raw in result.items():
-                    if benchmark["type"] in ["rpc", "io"]:
-                        parsed = load_data(raw)
-                    else:
-                        parsed = raw
-                    backends_parsed[backend] = auto_generate_data_points(parsed)
-
-                [shardless_metrics, sharded_metrics] = join_metrics(backends_parsed)
+                [shardless_metrics, sharded_metrics] = self._run_iteration(
+                    benchmark, run_output_dir, config_path, self.plot_generator
+                )
                 metrics_runs.append({"run_id": i, "sharded": sharded_metrics, "shardless": shardless_metrics})
 
             (combined_sharded, combined_shardless) = join_stats(metrics_runs)
@@ -165,6 +131,47 @@ class BenchmarkSuiteRunner:
         if self.plotting_config.generate_pdf and per_benchmark_pdfs:
             logger.info("Merging pdfs")
             merge_pdfs(input_pdfs=per_benchmark_pdfs, output_pdf=self.output_dir / SUITE_SUMMARY_PDF_FILENAME)
+
+    def _run_iteration(
+        self, benchmark: Benchmark, run_output_dir: Path, config_path: Path, plot_generator: PlotGenerator
+    ) -> tuple[TreeDict[dict[str, Any]], TreeDict[dict[str, dict[int, Any]]]]:
+        result: dict = None
+        if benchmark["type"] == "io":
+            result = run_io_test(
+                self.io_config,
+                config_path,
+                run_output_dir,
+                self.backends,
+                self.params["skip_async_workers_cpuset"],
+            )
+        elif benchmark["type"] == "rpc":
+            result = run_rpc_test(
+                self.rpc_config,
+                config_path,
+                run_output_dir,
+                self.backends,
+                self.params["skip_async_workers_cpuset"],
+            )
+        elif benchmark["type"] == "simple-query":
+            result = PerfSimpleQueryTestRunner(
+                self.scylla_config,
+                config_path,
+                run_output_dir,
+                self.backends,
+                self.params["skip_async_workers_cpuset"],
+            ).run()
+        else:
+            raise Exception(f"Unknown benchmark type {benchmark['type']}")
+
+        backends_parsed = {}
+        for backend, raw in result.items():
+            if benchmark["type"] in ["rpc", "io"]:
+                parsed = load_data(raw)
+            else:
+                parsed = raw
+            backends_parsed[backend] = auto_generate_data_points(parsed)
+
+        return join_metrics(backends_parsed)
 
 
 def _plot_runs(benchmark: Benchmark, output_dir: Path, plot_generator: PlotGenerator) -> None:

--- a/benchmarks.py
+++ b/benchmarks.py
@@ -168,9 +168,8 @@ class BenchmarkSuiteRunner:
                 self.scylla_config,
                 config_path,
                 run_output_dir,
-                backend,
                 self.params["skip_async_workers_cpuset"],
-            ).run()
+            ).run(backend)
         else:
             raise Exception(f"Unknown benchmark type {benchmark['type']}")
 

--- a/benchmarks.py
+++ b/benchmarks.py
@@ -11,7 +11,7 @@ from config_versioning import get_config_version, make_proportional_splitter, up
 from generate import PlotGenerator
 from log import get_logger
 from metadata import BenchmarkMetadataHolder
-from parse import auto_generate_data_points, join_metrics
+from parse import RawBackendData, auto_generate_data_points, join_metrics
 from pdf_summary import generate_benchmark_summary_pdf, merge_pdfs
 from run_io import run_io_test
 from run_rpc import run_rpc_test
@@ -133,7 +133,7 @@ class BenchmarkSuiteRunner:
     def _run_iteration(
         self, benchmark: Benchmark, run_output_dir: Path, config_path: Path
     ) -> tuple[TreeDict[dict[str, Any]], TreeDict[dict[str, dict[int, Any]]]]:
-        result: dict[dict[str, Any]] = {}
+        result: dict[str, tuple[TreeDict[Any], TreeDict[dict[int, Any]]]] = {}
 
         for backend in self.backends:
             logger.info(f"Running iteration for backend {backend}")
@@ -146,7 +146,7 @@ class BenchmarkSuiteRunner:
 
     def _run_benchmark(
         self, benchmark: Benchmark, run_output_dir: Path, config_path: Path, backend: str
-    ) -> dict[str, Any]:
+    ) -> RawBackendData:
         if benchmark["type"] == "io":
             return run_io_test(
                 self.io_config,

--- a/benchmarks.py
+++ b/benchmarks.py
@@ -11,7 +11,7 @@ from config_versioning import get_config_version, make_proportional_splitter, up
 from generate import PlotGenerator
 from log import get_logger
 from metadata import BenchmarkMetadataHolder
-from parse import auto_generate_data_points, join_metrics, load_data
+from parse import auto_generate_data_points, join_metrics
 from pdf_summary import generate_benchmark_summary_pdf, merge_pdfs
 from run_io import run_io_test
 from run_rpc import run_rpc_test
@@ -135,43 +135,46 @@ class BenchmarkSuiteRunner:
     def _run_iteration(
         self, benchmark: Benchmark, run_output_dir: Path, config_path: Path, plot_generator: PlotGenerator
     ) -> tuple[TreeDict[dict[str, Any]], TreeDict[dict[str, dict[int, Any]]]]:
-        result: dict = None
+        result: dict[dict[str, Any]] = {}
+
+        for backend in self.backends:
+            logger.info(f"Running iteration for backend {backend}")
+            raw_results = self._run_benchmark(benchmark, run_output_dir, config_path, backend)
+            if raw_results is None:
+                raise Exception(f"Backend {backend} did not return any result")
+            result[backend] = auto_generate_data_points(raw_results)
+
+        return join_metrics(result)
+
+    def _run_benchmark(
+        self, benchmark: Benchmark, run_output_dir: Path, config_path: Path, backend: str
+    ) -> dict[str, Any]:
         if benchmark["type"] == "io":
-            result = run_io_test(
+            return run_io_test(
                 self.io_config,
                 config_path,
                 run_output_dir,
-                self.backends,
+                backend,
                 self.params["skip_async_workers_cpuset"],
             )
         elif benchmark["type"] == "rpc":
-            result = run_rpc_test(
+            return run_rpc_test(
                 self.rpc_config,
                 config_path,
                 run_output_dir,
-                self.backends,
+                backend,
                 self.params["skip_async_workers_cpuset"],
             )
         elif benchmark["type"] == "simple-query":
-            result = PerfSimpleQueryTestRunner(
+            return PerfSimpleQueryTestRunner(
                 self.scylla_config,
                 config_path,
                 run_output_dir,
-                self.backends,
+                backend,
                 self.params["skip_async_workers_cpuset"],
             ).run()
         else:
             raise Exception(f"Unknown benchmark type {benchmark['type']}")
-
-        backends_parsed = {}
-        for backend, raw in result.items():
-            if benchmark["type"] in ["rpc", "io"]:
-                parsed = load_data(raw)
-            else:
-                parsed = raw
-            backends_parsed[backend] = auto_generate_data_points(parsed)
-
-        return join_metrics(backends_parsed)
 
 
 def _plot_runs(benchmark: Benchmark, output_dir: Path, plot_generator: PlotGenerator) -> None:

--- a/parse.py
+++ b/parse.py
@@ -5,8 +5,10 @@ from yaml import safe_load
 
 from tree import TreeDict
 
+type RawBackendData = list[dict]
 
-def load_data(raw_output: str) -> Any:
+
+def load_data(raw_output: str) -> RawBackendData:
     """Extract embedded YAML from a client output text and parse it.
 
     The client output is expected to contain a YAML document separated by the
@@ -24,14 +26,18 @@ def load_data(raw_output: str) -> Any:
 
     yaml_part = raw_output.split("---\n")[1]
     yaml_part = yaml_part.removesuffix("...\n")
-    return safe_load(yaml_part)
+
+    loaded = safe_load(yaml_part)
+    if not isinstance(loaded, list):
+        raise ValueError("Expected the YAML payload to be a list of dicts")
+    return loaded
 
 
 SHARD_KEY = "shard"
 
 
 def auto_generate_data_points(
-    backend_data: list[dict],
+    backend_data: RawBackendData,
 ) -> tuple[TreeDict[Any], TreeDict[dict[int, Any]]]:
     """
     Parse backend data and separate sharded and shardless metrics.

--- a/pdf_summary.py
+++ b/pdf_summary.py
@@ -29,7 +29,7 @@ def _read_png_size(path: Path) -> tuple[int, int]:
         sig = f.read(8)
         if sig != b"\x89PNG\r\n\x1a\n":
             raise ValueError(f"Not a PNG file: {path}")
-        ihdr_len = f.read(4)
+        _ = f.read(4)
         ihdr_type = f.read(4)
         if ihdr_type != b"IHDR":
             raise ValueError(f"Invalid PNG header (missing IHDR): {path}")

--- a/run_io.py
+++ b/run_io.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from log import get_logger, warn_if_not_release
 from remote import CmdOutput, IoTesterParams, Remote
+from parse import RawBackendData, load_data
 
 logger = get_logger()
 
@@ -14,7 +15,7 @@ class IOTestRunner:
         io_runner_config: dict,
         config_path: Path,
         run_output_dir: Path,
-        backends: list[str],
+        backend: str,
         skip_async_workers_cpuset: bool,
     ) -> None:
         self.tester_path: Path = Path(io_runner_config["tester_path"]).expanduser().resolve()
@@ -24,7 +25,7 @@ class IOTestRunner:
         self.asymmetric_app_cpuset = io_runner_config["asymmetric_app_cpuset"]
         self.asymmetric_async_worker_cpuset = io_runner_config["asymmetric_async_worker_cpuset"]
         self.symmetric_cpuset = io_runner_config["symmetric_cpuset"]
-        self.backends = backends
+        self.backend = backend
         self.skip_async_workers_cpuset = skip_async_workers_cpuset
         if (remote := io_runner_config.get("remote", None)) is not None:
             remote = Remote(remote)
@@ -96,26 +97,21 @@ class IOTestRunner:
         if (err := result.returncode) != 0:
             raise RuntimeError(f"Tester failed with exit code {err}")
 
-        return result.stdout
+        return load_data(result.stdout)
 
-    def run(self) -> dict:
-        backends_data_raw = {}
-
-        for backend in self.backends:
-            if backend == "asymmetric_io_uring":
-                if self.skip_async_workers_cpuset:
-                    backends_data_raw[backend] = self.__run_test(backend, backend, self.asymmetric_app_cpuset, None)
-                else:
-                    backends_data_raw[backend] = self.__run_test(
-                        backend, backend, self.asymmetric_app_cpuset, self.asymmetric_async_worker_cpuset
-                    )
+    def run(self) -> RawBackendData:
+        if self.backend == "asymmetric_io_uring":
+            if self.skip_async_workers_cpuset:
+                return self.__run_test(self.backend, self.backend, self.asymmetric_app_cpuset, None)
             else:
-                backends_data_raw[backend] = self.__run_test(backend, backend, self.symmetric_cpuset, None)
+                return self.__run_test(
+                    self.backend, self.backend, self.asymmetric_app_cpuset, self.asymmetric_async_worker_cpuset
+                )
+        else:
+            return self.__run_test(self.backend, self.backend, self.symmetric_cpuset, None)
 
-        return backends_data_raw
 
-
-def run_io_test(io_runner_config: dict, config_path, run_output_dir, backends, skip_async_workers_cpuset: bool) -> dict:
-    return IOTestRunner(
-        io_runner_config, Path(config_path), Path(run_output_dir), backends, skip_async_workers_cpuset
-    ).run()
+def run_io_test(
+    io_runner_config: dict, config_path, run_output_dir: Path, backend: str, skip_async_workers_cpuset: bool
+) -> RawBackendData:
+    return IOTestRunner(io_runner_config, Path(config_path), run_output_dir, backend, skip_async_workers_cpuset).run()

--- a/run_io.py
+++ b/run_io.py
@@ -3,8 +3,8 @@ from os import PathLike
 from pathlib import Path
 
 from log import get_logger, warn_if_not_release
-from remote import CmdOutput, IoTesterParams, Remote
 from parse import RawBackendData, load_data
+from remote import CmdOutput, IoTesterParams, Remote
 
 logger = get_logger()
 
@@ -71,7 +71,9 @@ class IOTestRunner:
                 process.wait()  # Clear zombie
                 raise
 
-    def __run_test(self, backend: str, output_filename: str, cpuset: str, async_worker_cpuset: str | None) -> str:
+    def __run_test(
+        self, backend: str, output_filename: str, cpuset: str, async_worker_cpuset: str | None
+    ) -> RawBackendData:
         logger.info(
             f"Running io_tester with backend {backend}, cpuset: {cpuset}, async worker cpuset: {async_worker_cpuset}"
         )

--- a/run_io.py
+++ b/run_io.py
@@ -15,7 +15,6 @@ class IOTestRunner:
         io_runner_config: dict,
         config_path: Path,
         run_output_dir: Path,
-        backend: str,
         skip_async_workers_cpuset: bool,
     ) -> None:
         self.tester_path: Path = Path(io_runner_config["tester_path"]).expanduser().resolve()
@@ -25,7 +24,6 @@ class IOTestRunner:
         self.asymmetric_app_cpuset = io_runner_config["asymmetric_app_cpuset"]
         self.asymmetric_async_worker_cpuset = io_runner_config["asymmetric_async_worker_cpuset"]
         self.symmetric_cpuset = io_runner_config["symmetric_cpuset"]
-        self.backend = backend
         self.skip_async_workers_cpuset = skip_async_workers_cpuset
         if (remote := io_runner_config.get("remote", None)) is not None:
             remote = Remote(remote)
@@ -99,19 +97,19 @@ class IOTestRunner:
 
         return load_data(result.stdout)
 
-    def run(self) -> RawBackendData:
-        if self.backend == "asymmetric_io_uring":
+    def run(self, backend: str) -> RawBackendData:
+        if backend == "asymmetric_io_uring":
             if self.skip_async_workers_cpuset:
-                return self.__run_test(self.backend, self.backend, self.asymmetric_app_cpuset, None)
+                return self.__run_test(backend, backend, self.asymmetric_app_cpuset, None)
             else:
                 return self.__run_test(
-                    self.backend, self.backend, self.asymmetric_app_cpuset, self.asymmetric_async_worker_cpuset
+                    backend, backend, self.asymmetric_app_cpuset, self.asymmetric_async_worker_cpuset
                 )
         else:
-            return self.__run_test(self.backend, self.backend, self.symmetric_cpuset, None)
+            return self.__run_test(backend, backend, self.symmetric_cpuset, None)
 
 
 def run_io_test(
-    io_runner_config: dict, config_path, run_output_dir: Path, backend: str, skip_async_workers_cpuset: bool
+    io_runner_config: dict, config_path: Path, run_output_dir: Path, backend: str, skip_async_workers_cpuset: bool
 ) -> RawBackendData:
-    return IOTestRunner(io_runner_config, Path(config_path), run_output_dir, backend, skip_async_workers_cpuset).run()
+    return IOTestRunner(io_runner_config, config_path, run_output_dir, skip_async_workers_cpuset).run(backend)

--- a/run_rpc.py
+++ b/run_rpc.py
@@ -3,8 +3,8 @@ from pathlib import Path
 from time import sleep
 
 from log import get_logger, warn_if_not_release
-from remote import CmdOutput, Remote, RemoteProcess, RpcTesterParams
 from parse import RawBackendData, load_data
+from remote import CmdOutput, Remote, RemoteProcess, RpcTesterParams
 
 logger = get_logger()
 
@@ -249,6 +249,4 @@ class RpcTestRunner:
 def run_rpc_test(
     rpc_runner_config: dict, config_path: Path, run_output_dir: Path, backend: str, skip_async_workers_cpuset: bool
 ) -> RawBackendData:
-    return RpcTestRunner(
-        rpc_runner_config, config_path, run_output_dir, skip_async_workers_cpuset
-    ).run(backend)
+    return RpcTestRunner(rpc_runner_config, config_path, run_output_dir, skip_async_workers_cpuset).run(backend)

--- a/run_rpc.py
+++ b/run_rpc.py
@@ -4,13 +4,19 @@ from time import sleep
 
 from log import get_logger, warn_if_not_release
 from remote import CmdOutput, Remote, RemoteProcess, RpcTesterParams
+from parse import RawBackendData, load_data
 
 logger = get_logger()
 
 
 class RpcTestRunner:
     def __init__(
-        self, rpc_runner_config: dict, config_path: Path, run_output_dir: Path, backends, skip_async_workers_cpuset
+        self,
+        rpc_runner_config: dict,
+        config_path: Path,
+        run_output_dir: Path,
+        backend: str,
+        skip_async_workers_cpuset: bool,
     ) -> None:
         self.tester_path: Path = Path(rpc_runner_config["tester_path"]).expanduser().resolve()
         self.config_path: Path = config_path.resolve()
@@ -22,7 +28,7 @@ class RpcTestRunner:
         self.asymmetric_client_app_cpuset = rpc_runner_config["asymmetric_client_app_cpuset"]
         self.asymmetric_client_async_worker_cpuset = rpc_runner_config["asymmetric_client_async_worker_cpuset"]
         self.symmetric_client_cpuset = rpc_runner_config["symmetric_client_cpuset"]
-        self.backends = backends
+        self.backend = backend
         self.skip_async_workers_cpuset = skip_async_workers_cpuset
         if (server_remote := rpc_runner_config.get("server_remote", None)) is not None:
             server_remote = Remote(server_remote)
@@ -178,7 +184,7 @@ class RpcTestRunner:
         server_async_worker_cpuset: str | None,
         client_cpuset: str,
         client_async_worker_cpuset: str | None,
-    ) -> str:
+    ) -> RawBackendData:
         logger.info(
             f"Running rpc_tester with backend {backend}, server cpuset: {server_cpuset}, server async worker cpuset: {server_async_worker_cpuset}, client cpuset: {client_cpuset}, client async worker cpuset: {client_async_worker_cpuset}"
         )
@@ -214,40 +220,37 @@ class RpcTestRunner:
         if client.returncode is not None and client.returncode != 0:
             raise RuntimeError(f"Client failed with exit code {client.returncode}")
 
-        return client.stdout
+        return load_data(client.stdout)
 
-    def run(self) -> dict:
-        backends_data_raw = {}
-
-        for backend in self.backends:
-            if backend == "asymmetric_io_uring":
-                if self.skip_async_workers_cpuset:
-                    backends_data_raw[backend] = self.__run_test(
-                        backend,
-                        backend,
-                        self.asymmetric_server_app_cpuset,
-                        None,
-                        self.asymmetric_client_app_cpuset,
-                        None,
-                    )
-                else:
-                    backends_data_raw[backend] = self.__run_test(
-                        backend,
-                        backend,
-                        self.asymmetric_server_app_cpuset,
-                        self.asymmetric_server_async_worker_cpuset,
-                        self.asymmetric_client_app_cpuset,
-                        self.asymmetric_client_async_worker_cpuset,
-                    )
-            else:
-                backends_data_raw[backend] = self.__run_test(
-                    backend, backend, self.symmetric_server_cpuset, None, self.symmetric_client_cpuset, None
+    def run(self) -> RawBackendData:
+        if self.backend == "asymmetric_io_uring":
+            if self.skip_async_workers_cpuset:
+                return self.__run_test(
+                    self.backend,
+                    self.backend,
+                    self.asymmetric_server_app_cpuset,
+                    None,
+                    self.asymmetric_client_app_cpuset,
+                    None,
                 )
+            else:
+                return self.__run_test(
+                    self.backend,
+                    self.backend,
+                    self.asymmetric_server_app_cpuset,
+                    self.asymmetric_server_async_worker_cpuset,
+                    self.asymmetric_client_app_cpuset,
+                    self.asymmetric_client_async_worker_cpuset,
+                )
+        else:
+            return self.__run_test(
+                self.backend, self.backend, self.symmetric_server_cpuset, None, self.symmetric_client_cpuset, None
+            )
 
-        return backends_data_raw
 
-
-def run_rpc_test(rpc_runner_config: dict, config_path, run_output_dir, backends, skip_async_workers_cpuset) -> dict:
+def run_rpc_test(
+    rpc_runner_config: dict, config_path, run_output_dir, backends, skip_async_workers_cpuset
+) -> RawBackendData:
     return RpcTestRunner(
         rpc_runner_config, Path(config_path), Path(run_output_dir), backends, skip_async_workers_cpuset
     ).run()

--- a/run_rpc.py
+++ b/run_rpc.py
@@ -15,7 +15,6 @@ class RpcTestRunner:
         rpc_runner_config: dict,
         config_path: Path,
         run_output_dir: Path,
-        backend: str,
         skip_async_workers_cpuset: bool,
     ) -> None:
         self.tester_path: Path = Path(rpc_runner_config["tester_path"]).expanduser().resolve()
@@ -28,7 +27,6 @@ class RpcTestRunner:
         self.asymmetric_client_app_cpuset = rpc_runner_config["asymmetric_client_app_cpuset"]
         self.asymmetric_client_async_worker_cpuset = rpc_runner_config["asymmetric_client_async_worker_cpuset"]
         self.symmetric_client_cpuset = rpc_runner_config["symmetric_client_cpuset"]
-        self.backend = backend
         self.skip_async_workers_cpuset = skip_async_workers_cpuset
         if (server_remote := rpc_runner_config.get("server_remote", None)) is not None:
             server_remote = Remote(server_remote)
@@ -222,12 +220,12 @@ class RpcTestRunner:
 
         return load_data(client.stdout)
 
-    def run(self) -> RawBackendData:
-        if self.backend == "asymmetric_io_uring":
+    def run(self, backend: str) -> RawBackendData:
+        if backend == "asymmetric_io_uring":
             if self.skip_async_workers_cpuset:
                 return self.__run_test(
-                    self.backend,
-                    self.backend,
+                    backend,
+                    backend,
                     self.asymmetric_server_app_cpuset,
                     None,
                     self.asymmetric_client_app_cpuset,
@@ -235,8 +233,8 @@ class RpcTestRunner:
                 )
             else:
                 return self.__run_test(
-                    self.backend,
-                    self.backend,
+                    backend,
+                    backend,
                     self.asymmetric_server_app_cpuset,
                     self.asymmetric_server_async_worker_cpuset,
                     self.asymmetric_client_app_cpuset,
@@ -244,13 +242,13 @@ class RpcTestRunner:
                 )
         else:
             return self.__run_test(
-                self.backend, self.backend, self.symmetric_server_cpuset, None, self.symmetric_client_cpuset, None
+                backend, backend, self.symmetric_server_cpuset, None, self.symmetric_client_cpuset, None
             )
 
 
 def run_rpc_test(
-    rpc_runner_config: dict, config_path, run_output_dir, backends, skip_async_workers_cpuset
+    rpc_runner_config: dict, config_path: Path, run_output_dir: Path, backend: str, skip_async_workers_cpuset: bool
 ) -> RawBackendData:
     return RpcTestRunner(
-        rpc_runner_config, Path(config_path), Path(run_output_dir), backends, skip_async_workers_cpuset
-    ).run()
+        rpc_runner_config, config_path, run_output_dir, skip_async_workers_cpuset
+    ).run(backend)

--- a/scylla_perf.py
+++ b/scylla_perf.py
@@ -8,6 +8,7 @@ from typing import override
 from yaml import safe_load
 
 from log import get_logger, warn_if_not_release
+from parse import RawBackendData
 
 logger = get_logger()
 
@@ -18,7 +19,7 @@ class OneExecutableTestRunner(ABC):
         test_config: dict,
         config_path: Path,
         run_output_dir: Path,
-        backends: list[str],
+        backend: str,
         skip_async_workers_cpuset: bool,
     ) -> None:
         super().__init__()
@@ -29,13 +30,13 @@ class OneExecutableTestRunner(ABC):
         self.asymmetric_app_cpuset = test_config["asymmetric_app_cpuset"]
         self.asymmetric_async_worker_cpuset = test_config["asymmetric_async_worker_cpuset"]
         self.symmetric_cpuset = test_config["symmetric_cpuset"]
-        self.backends = backends
+        self.backend = backend
         self.skip_async_workers_cpuset = skip_async_workers_cpuset
 
         warn_if_not_release(self.tester_path)
 
         logger.debug(
-            f"Initialized single executable test runner with tester_path={self.tester_path}, config_path={self.config_path}, run_output_dir={self.run_output_dir}, asymmetric_app_cpuset={self.asymmetric_app_cpuset}, asymmetric_async_worker_cpuset={self.asymmetric_async_worker_cpuset}, symmetric_cpuset={self.symmetric_cpuset}, backends={self.backends}, skip_async_workers_cpuset={self.skip_async_workers_cpuset}"
+            f"Initialized single executable test runner with tester_path={self.tester_path}, config_path={self.config_path}, run_output_dir={self.run_output_dir}, asymmetric_app_cpuset={self.asymmetric_app_cpuset}, asymmetric_async_worker_cpuset={self.asymmetric_async_worker_cpuset}, symmetric_cpuset={self.symmetric_cpuset}, backend={self.backend}, skip_async_workers_cpuset={self.skip_async_workers_cpuset}"
         )
 
     def run_tester_with_additional_args(
@@ -84,26 +85,20 @@ class OneExecutableTestRunner(ABC):
     def _run_test(self, backend: str, cpuset: str, async_worker_cpuset: str | None):
         pass
 
-    def run(self) -> dict[str]:
-        backends_data_parsed = {}
-
-        for backend in self.backends:
-            if backend == "asymmetric_io_uring":
-                if self.skip_async_workers_cpuset:
-                    backends_data_parsed[backend] = self._run_test(backend, self.asymmetric_app_cpuset, None)
-                else:
-                    backends_data_parsed[backend] = self._run_test(
-                        backend, self.asymmetric_app_cpuset, self.asymmetric_async_worker_cpuset
-                    )
+    def run(self) -> RawBackendData:
+        backend = self.backend
+        if backend == "asymmetric_io_uring":
+            if self.skip_async_workers_cpuset:
+                return self._run_test(backend, self.asymmetric_app_cpuset, None)
             else:
-                backends_data_parsed[backend] = self._run_test(backend, self.asymmetric_app_cpuset, None)
-
-        return backends_data_parsed
+                return self._run_test(backend, self.asymmetric_app_cpuset, self.asymmetric_async_worker_cpuset)
+        else:
+            return self._run_test(backend, self.asymmetric_app_cpuset, None)
 
 
 class PerfSimpleQueryTestRunner(OneExecutableTestRunner):
     @override
-    def _run_test(self, backend, cpuset, async_worker_cpuset) -> list[dict]:
+    def _run_test(self, backend, cpuset, async_worker_cpuset) -> RawBackendData:
         json_output_path = self.run_output_dir / f"{backend}.json"
 
         with open(self.config_path) as f:

--- a/scylla_perf.py
+++ b/scylla_perf.py
@@ -95,7 +95,7 @@ class OneExecutableTestRunner(ABC):
 
 class PerfSimpleQueryTestRunner(OneExecutableTestRunner):
     @override
-    def _run_test(self, backend, cpuset, async_worker_cpuset) -> RawBackendData:
+    def _run_test(self, backend: str, cpuset: str, async_worker_cpuset: str | None) -> RawBackendData:
         json_output_path = self.run_output_dir / f"{backend}.json"
 
         with open(self.config_path) as f:

--- a/scylla_perf.py
+++ b/scylla_perf.py
@@ -19,7 +19,6 @@ class OneExecutableTestRunner(ABC):
         test_config: dict,
         config_path: Path,
         run_output_dir: Path,
-        backend: str,
         skip_async_workers_cpuset: bool,
     ) -> None:
         super().__init__()
@@ -30,13 +29,12 @@ class OneExecutableTestRunner(ABC):
         self.asymmetric_app_cpuset = test_config["asymmetric_app_cpuset"]
         self.asymmetric_async_worker_cpuset = test_config["asymmetric_async_worker_cpuset"]
         self.symmetric_cpuset = test_config["symmetric_cpuset"]
-        self.backend = backend
         self.skip_async_workers_cpuset = skip_async_workers_cpuset
 
         warn_if_not_release(self.tester_path)
 
         logger.debug(
-            f"Initialized single executable test runner with tester_path={self.tester_path}, config_path={self.config_path}, run_output_dir={self.run_output_dir}, asymmetric_app_cpuset={self.asymmetric_app_cpuset}, asymmetric_async_worker_cpuset={self.asymmetric_async_worker_cpuset}, symmetric_cpuset={self.symmetric_cpuset}, backend={self.backend}, skip_async_workers_cpuset={self.skip_async_workers_cpuset}"
+            f"Initialized single executable test runner with tester_path={self.tester_path}, config_path={self.config_path}, run_output_dir={self.run_output_dir}, asymmetric_app_cpuset={self.asymmetric_app_cpuset}, asymmetric_async_worker_cpuset={self.asymmetric_async_worker_cpuset}, symmetric_cpuset={self.symmetric_cpuset}, skip_async_workers_cpuset={self.skip_async_workers_cpuset}"
         )
 
     def run_tester_with_additional_args(
@@ -85,8 +83,7 @@ class OneExecutableTestRunner(ABC):
     def _run_test(self, backend: str, cpuset: str, async_worker_cpuset: str | None):
         pass
 
-    def run(self) -> RawBackendData:
-        backend = self.backend
+    def run(self, backend: str) -> RawBackendData:
         if backend == "asymmetric_io_uring":
             if self.skip_async_workers_cpuset:
                 return self._run_test(backend, self.asymmetric_app_cpuset, None)


### PR DESCRIPTION
- break down our big ass method
- unify what testers returned - list[dict]
- invoke testers per benchmark, not with list of benchmarks